### PR TITLE
Extending JSON-API compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Argo expects as the result of these functions a map with the following keys:
 * `:status`: Use to override the status of responses. Defaults to 400 for error responses and 200 for valid responses.
 * `:exclude-source`: Use this to exclude the source object as per the JSON API spec in error responses.
 * `:count`: argo provides automatic generation of pagination links if using pagination for `:find`. Use `:count` to let argo know how many total objects exist when implementing pagination.
+* `:included` You may optionally include top-level, related resource objects.
+* `:resource-objects` You may optionally include related resource identifier objects.
 
 In most circumstances it will probably only be necessary to include either `:data` or `:errors`.
 
@@ -266,8 +268,9 @@ This should return the following reponse.
             "hero": {
                 "links": {
                     "related": "/v1/achievements/1/hero"
-                }
-            }
+                },
+                "data": { "type": "heroes", "id": 1 }
+            },
         },
         "type": "achievements"
     }

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Argo expects as the result of these functions a map with the following keys:
 * `:status`: Use to override the status of responses. Defaults to 400 for error responses and 200 for valid responses.
 * `:exclude-source`: Use this to exclude the source object as per the JSON API spec in error responses.
 * `:count`: argo provides automatic generation of pagination links if using pagination for `:find`. Use `:count` to let argo know how many total objects exist when implementing pagination.
-* `:included` You may optionally include top-level, related resource objects.
-* `:resource-objects` You may optionally include related resource identifier objects.
+* `:included` You may _optionally_ include top-level, related resource objects.
+* `:resource-identifiers` You may _optionally_ include related resource identifier objects.
 
 In most circumstances it will probably only be necessary to include either `:data` or `:errors`.
 

--- a/README.md
+++ b/README.md
@@ -33,12 +33,20 @@ Each operation expects its implementation to be a function with a ring request o
 Argo expects as the result of these functions a map with the following keys:
 
 * `:data`: The data which will be returned in the API response. This should be a map for a single resource (as implemented with `:get`) or a vector/sequence for `:find`.
+  - Optional data: `:resource-identifiers` You may _optionally_ include related resource identifier objects.
 * `:errors`: A map of keywords and string values. Will be converted to the JSON API error format. Works well with Prismatic schema error types.
 * `:status`: Use to override the status of responses. Defaults to 400 for error responses and 200 for valid responses.
 * `:exclude-source`: Use this to exclude the source object as per the JSON API spec in error responses.
 * `:count`: argo provides automatic generation of pagination links if using pagination for `:find`. Use `:count` to let argo know how many total objects exist when implementing pagination.
 * `:included` You may _optionally_ include top-level, related resource objects.
-* `:resource-identifiers` You may _optionally_ include related resource identifier objects.
+  - for example:
+  ```clojure
+  {
+    :data {...}
+    :included {:heroes [{:id "12345"
+                         :name "Jason"}]}
+  }
+  ```
 
 In most circumstances it will probably only be necessary to include either `:data` or `:errors`.
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Argo expects as the result of these functions a map with the following keys:
   ```clojure
   {
     :data {...}
-    :included {:heroes [{:id "12345"
-                         :name "Jason"}]}
+    :included {:heroes [{:id 1 :name "Jason"}]
+               :ally {:id 2 :name "Medea"}}
   }
   ```
 
@@ -281,7 +281,20 @@ This should return the following reponse.
             },
         },
         "type": "achievements"
-    }
+    },
+    "included": [
+        {
+            "type": "heroes",
+            "id": "1",
+            "attributes": {
+                "created": "2017-02-12T00:09:59Z",
+                "name": "Jason"
+            },
+            "links": {
+              "self": "/v1/heroes/1"
+            }
+        }
+    ]
 }
 ```
 

--- a/example/src/example/api.clj
+++ b/example/src/example/api.clj
@@ -64,7 +64,7 @@
    :rels {:hero {:type :heroes
                  :foreign-key :hero
                  :get (fn [req]
-                        {:data (db/get-achievement-hero (parse-id (-> req :params :id)))})}}})
+                          {:data (db/get-achievement-hero (parse-id (-> req :params :id)))})}}})
 
 (defapi api
   {:base-url "/v1"

--- a/example/src/example/api.clj
+++ b/example/src/example/api.clj
@@ -48,7 +48,8 @@
            {:data (db/find-achievements)})
 
    :get (fn [req]
-          {:data (db/get-achievement (parse-id (-> req :params :id)))})
+          {:data (db/get-achievement (parse-id (-> req :params :id)))
+           :included {:heroes (db/get-achievement-hero (parse-id (-> req :params :id)))}})
 
    :create (fn [req]
              (if-let [errors (s/check NewAchievement (:body req))]

--- a/example/src/example/db.clj
+++ b/example/src/example/db.clj
@@ -79,7 +79,7 @@
 (defn get-achievement-hero
   [id]
   (when (integer? id)
-    (let [q (str "SELECT heroes.id AS id, heroes.name AS name, heroes.created AS created "
+    (let [q (str "SELECT heroes.id AS id, heroes.name AS name, heroes.created AS created, heroes.birthplace AS birthplace "
                  "FROM heroes, achievements "
                  "WHERE achievements.id = ? AND heroes.id = achievements.id")]
       (first (jdbc/query db [q id])))))

--- a/src/argo/core.clj
+++ b/src/argo/core.clj
@@ -95,27 +95,27 @@
 (comment (dissoc (apply dissoc x (map (fn [[k v]] (:foreign-key v)) rels)) primary-key))
 
 (defn build-relationships
-  "takes object relationship map, primary key and returns json-api formatted map for relationships"
-  [type x primary-key rels]
+  "takes , primary key and returns json-api formatted map for relationships"
+  [rel-type x primary-key rels]
   (apply merge
          (map (fn [[k v]]
                 {k (merge {:links
-                           {:related (str base-url "/" type "/" (get x primary-key) "/" (name k))}}
+                           {:related (str base-url "/" rel-type "/" (get x primary-key) "/" (name k))}}
                           (when-let [data (k (:resource-objects x))]
                             {:data data}))})
                  rels)))
 
 (defn x-to-api
-  [type x primary-key & [rels]]
+  [rel-type x primary-key & [rels]]
   (when x
-    (merge {:type type
+    (merge {:type rel-type
             :id (str (get x primary-key))
             :attributes (-> x
                             (dissoc (map (fn [[k v]] (:foreign-key v)) rels))
                             (dissoc primary-key)
                             (dissoc :resource-objects))
-            :links {:self (str base-url "/" type "/" (get x primary-key))}}
-           (when rels {:relationships (build-relationships type x primary-key rels)}))))
+            :links {:self (str base-url "/" rel-type "/" (get x primary-key))}}
+           (when rels {:relationships (build-relationships rel-type x primary-key rels)}))))
 
 (defn wrap-pagination
   [default-limit max-limit]

--- a/src/argo/core.clj
+++ b/src/argo/core.clj
@@ -104,10 +104,14 @@
                             (dissoc primary-key)
                             (dissoc :included))
             :links {:self (str base-url "/" type "/" (get x primary-key))}}
-           (when rels {:relationships (apply merge (map (fn [[k v]]
-                                                          {k {:links {:related (str base-url "/" type "/" (get x primary-key) "/" (name k))}
-                                                              :data (get-in x [:included k])}})
-                                                        rels))}))))
+           (when rels {:relationships
+                       (apply merge
+                              (map (fn [[k v]]
+                                     {k (merge {:links
+                                                {:related (str base-url "/" type "/" (get x primary-key) "/" (name k))}}
+                                               (when-let [included (get-in x [:included k])]
+                                                 {:data included}))})
+                                   rels))}))))
 
 (defn wrap-pagination
   [default-limit max-limit]

--- a/src/argo/core.clj
+++ b/src/argo/core.clj
@@ -317,7 +317,14 @@
                                                                  :meta ~m))
                                                            `((ok (x-to-api ~typ ~data ~primary-key ~relations) :meta ~m))))))))
                                       ~@(when create
-                                          `(:post (rel-req ~create ~req)))
+                                          `(:post (let [{data# :data
+                                                         errors# :errors
+                                                         exclude-source# :exclude-source
+                                                         status# :status
+                                                         m# :meta} (~create ~req)]
+                                                    (if errors#
+                                                      (bad-req errors# :status status# :exclude-source exclude-source#)
+                                                      (ok (x-to-api ~typ data# ~primary-key ~rels) :status 201 :meta m#)))))
 
                                       ~@(when update
                                           `(:patch (rel-req ~update ~req)))

--- a/src/argo/core.clj
+++ b/src/argo/core.clj
@@ -252,11 +252,12 @@
                                   status# :status
                                   exclude-source# :exclude-source
                                   errors# :errors
-                                  m# :meta} (~get-one ~req)]
+                                  m# :meta
+                                  included# :included} (~get-one ~req)]
                              (cond
                                errors# (bad-req errors# :status status# :exclude-source exclude-source#)
                                (nil? data#) (not-found)
-                               :else (ok (x-to-api ~typ data# ~primary-key ~rels) :meta m#)))))
+                               :else (ok (x-to-api ~typ data# ~primary-key ~rels) :meta m# :included included#)))))
 
                 ~@(when update
                     `(:patch (let [{data# :data

--- a/src/argo/core.clj
+++ b/src/argo/core.clj
@@ -101,7 +101,7 @@
          (map (fn [[k v]]
                 {k (merge {:links
                            {:related (str base-url "/" rel-type "/" (get x primary-key) "/" (name k))}}
-                          (when-let [data (k (:resource-objects x))]
+                          (when-let [data (k (:resource-identifiers x))]
                             {:data data}))})
                  rels)))
 
@@ -113,7 +113,7 @@
             :attributes (-> x
                             (dissoc (map (fn [[k v]] (:foreign-key v)) rels))
                             (dissoc primary-key)
-                            (dissoc :resource-objects))
+                            (dissoc :resource-identifiers))
             :links {:self (str base-url "/" rel-type "/" (get x primary-key))}}
            (when rels {:relationships (build-relationships rel-type x primary-key rels)}))))
 

--- a/src/argo/core.clj
+++ b/src/argo/core.clj
@@ -129,7 +129,7 @@
   (when (not-empty included)
         (->> included
             (map (fn [[typ included-of-type]]
-                   (if (seq? included-of-type)
+                   (if (coll? included-of-type)
                      (map (fn [include] (x-to-api (name typ) include :id)) included-of-type)
                      [(x-to-api (name typ) included-of-type :id)])))
             (reduce (fn [acc curr] (into acc curr))))))


### PR DESCRIPTION
I'm experimenting with added support for [compound documents](http://jsonapi.org/format/#document-compound-documents) and [resource identifier objects](http://jsonapi.org/format/#document-resource-identifier-objects) based on work started by @joshuamiller.

- supports responding with resource identifier objects if included in response data
  - http://jsonapi.org/format/#document-resource-identifier-objects
- partial support for inclusion of related resources
  - http://jsonapi.org/format/#fetching-includes
  - api authors may include related resources when handling requests
  - __limitation:__ no support for `?includes=<resource>` req param. returns `400` error if client attempts to fetch included resources via `?included` param per json-api spec.


Example map returned from request handler:
```clojure
{
  :data {...
         :resource-identifiers [{:type "heroes" :id 1}]
         ...}
  :included {:heroes [{:id 1 :name "Jason"}]
                   :ally {:id 2 :name "Medea"}}
}
```